### PR TITLE
Add a global dependency of Homebrew::Tap for Package

### DIFF
--- a/manifests/tap.pp
+++ b/manifests/tap.pp
@@ -19,3 +19,5 @@ define homebrew::tap($source) {
     recurse => true,
   }
 }
+
+Homebrew::Tap <| |> -> Package <| |>


### PR DESCRIPTION
The idea is that no packages should be installed until all the taps have been configured. Not sure if this will have unexpected side effects though.
