### PR TITLE
FormulaInstaller#install_bottle? is gone; update monkeypatch

### DIFF
--- a/files/boxen-monkeypatches.rb
+++ b/files/boxen-monkeypatches.rb
@@ -33,6 +33,12 @@ class FormulaInstaller
     false
   end
 
+  if defined? install_bottle?
+    def install_bottle? *args
+      have_boxen_bottle?
+    end
+  end
+
   alias orig_pour_bottle? pour_bottle?
   def pour_bottle? install_bottle_options={:warn=>false}
     return false unless have_boxen_bottle?


### PR DESCRIPTION
This fixes the failures I've been seeing over the past few days where missing boxen bottles cause installs to completely fail.
