### PR TITLE
Only run 'brew update' if your platform is Darwin

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -6,8 +6,10 @@
 class homebrew::repo {
   include homebrew
 
-  exec { 'brew update':
-    refreshonly => true,
-    require     => Class['homebrew']
+  if $::osfamily == 'Darwin' {
+    exec { 'brew update':
+      refreshonly => true,
+      require     => Class['homebrew']
+    }
   }
 }


### PR DESCRIPTION
cc @wfarr @dgoodlad

This ensures that `brew update` will only be run if we're on an OS X box.
