### PR TITLE
Update Homebrew organization location.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,7 @@
 
 [![Build Status](https://travis-ci.org/boxen/puppet-homebrew.png?branch=master)](https://travis-ci.org/boxen/puppet-homebrew)
 
-Install [Homebrew](http://mxcl.github.com/homebrew), a package manager
-for Mac OS X.
+Install [Homebrew](http://brew.sh), a package manager for Mac OS X.
 
 ## Usage
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -19,7 +19,7 @@ class homebrew(
   include homebrew::repo
 
   repository { $installdir:
-    source => 'mxcl/homebrew',
+    source => 'Homebrew/homebrew',
     user   => $::boxen_user
   }
 

--- a/spec/classes/homebrew_spec.rb
+++ b/spec/classes/homebrew_spec.rb
@@ -8,7 +8,7 @@ describe "homebrew" do
 
   it do
     should contain_repository(dir).with({
-      :source => "mxcl/homebrew",
+      :source => "Homebrew/homebrew",
       :user   => "testuser"
     })
 


### PR DESCRIPTION
Homebrew has moved to an organisation rather than being on mxcl's GitHub account. This won't change anything at runtime but is just nicer for future use.
