### PR TITLE
Fix ensure_resource on directory tree for boxen brews

### DIFF
--- a/manifests/formula.pp
+++ b/manifests/formula.pp
@@ -21,6 +21,6 @@ define homebrew::formula($source = undef) {
 
   file { "${boxen_tapdir}/${name}.rb":
     source  => $formula_source,
-    require => File[$boxen_tapdir]
+    require => File[$boxen_tapdir_root, $boxen_tapdir]
   }
 }


### PR DESCRIPTION
Version 1.9.1 pushed a change which creates `Library/Taps/boxen/hombrew-brews` except it assumes `Library/Taps/boxen` already exists.

Puppet doesn't implicitly create directory trees, you need to do it explicitly as per http://www.puppetcookbook.com/posts/creating-a-directory-tree.html
