### PR TITLE
Pour bottles to the correct directory

### DIFF
--- a/files/boxen-bottle-hooks.rb
+++ b/files/boxen-bottle-hooks.rb
@@ -49,8 +49,11 @@ module BoxenBottles
     success = system "curl", "--fail", "--progress-bar", "--output", cache_file, url
     raise "Boxen: Failed to download resource \"#{name}\"" unless success
 
-    ohai "Boxen: Pouring #{file}"
-    system "tar", "-xf", cache_file, "-C", HOMEBREW_CELLAR
+    bottle_install_dir = formula.prefix
+    bottle_install_dir.mkpath
+
+    ohai "Boxen: Pouring #{file} to #{bottle_install_dir}"
+    system "tar", "-xf", cache_file, "-C", bottle_install_dir, "--strip-components=2"
 
     true
   end


### PR DESCRIPTION
- If a bottle includes a revision number, homebrew expects it to
  be installed to a directory of the form bottle-name/version_revision
- This change simply extracts the bottle to the exact directory that
  homebrew expects it to be in, by grabbing that directory off of the
  formula definition

In my case boxen was failing to install `ossp-uuid`, because `boxen-bottle-hooks` was extracting it to 

`/opt/boxen/homebrew/Cellar/ossp-uuid/1.6.2`

but homebrew was expecting to find it in

`/opt/boxen/homebrew/Cellar/ossp-uuid/1.6.2_1`

Homebrew gets the expected directory name via `formula.prefix` ([code](https://github.com/Homebrew/homebrew/blob/8144d1b183c7384b704b0ed5dae2976f819d2e3b/Library/Homebrew/formula.rb#L147-L149)), and will [raise if the directory doesn't exist](https://github.com/Homebrew/homebrew/blob/8144d1b183c7384b704b0ed5dae2976f819d2e3b/Library/Homebrew/keg.rb#L98-L99).
