### PR TITLE
Handle formula revisions when downloading

### DIFF
--- a/files/boxen-bottle-hooks.rb
+++ b/files/boxen-bottle-hooks.rb
@@ -9,7 +9,8 @@ require "uri"
 # Puppet so that manual installs and indirect dependencies are also supported.
 module BoxenBottles
   def self.file(formula)
-    "#{formula.name}-#{formula.version}.tar.bz2"
+    revision = formula.revision > 0 ? "_#{formula.revision}" : ""
+    "#{formula.name}-#{formula.version}#{revision}.tar.bz2"
   end
 
   def self.url(formula)


### PR DESCRIPTION
This used to manifest in issues like this:

```
brew boxen-install boxen/brews/memcached
==> Installing memcached dependency: libevent
==> Boxen: Downloading http://s3.amazonaws.com/boxen-downloads/homebrew/10.10/libevent-2.0.21.tar.bz2
######################################################################## 100.0%
==> Boxen: Pouring libevent-2.0.21.tar.bz2
Warning: Nothing was installed to /opt/boxen/homebrew/Cellar/libevent/2.0.21_1
Error: /opt/boxen/homebrew/Cellar/libevent/2.0.21_1 is not a directory
```
