### PR TITLE
Fix S3 endpoint

### DIFF
--- a/files/boxen-bottle-hooks.rb
+++ b/files/boxen-bottle-hooks.rb
@@ -18,7 +18,7 @@ module BoxenBottles
     host   = ENV['BOXEN_S3_HOST'] || 's3.amazonaws.com'
     bucket = ENV['BOXEN_S3_BUCKET'] || 'boxen-downloads'
 
-    "http://#{host}/#{bucket}/homebrew/#{os}/#{file}"
+    "http://#{bucket}.#{host}/homebrew/#{os}/#{file}"
   end
 
   def self.bottled?(formula)


### PR DESCRIPTION
Amazon is now redirecting on requests that don't use bucket-specific endpoint hosts:

``` xml
<?xml version="1.0" encoding="UTF-8"?>
<Error>
  <Code>PermanentRedirect</Code>
  <Message>The bucket you are attempting to access must be addressed using the specified endpoint. Please send all future requests to this endpoint.</Message>
  <Bucket>foobar-bottles</Bucket>
  <Endpoint>foobar-bottles.s3.amAzonaws.com</Endpoint>i
  <RequestId>bar</RequestId>
  <HostId>bat</HostId>
</Error>
```

This results in [`BoxenBottles.bottled?`](https://github.com/boxen/puppet-homebrew/blob/master/files/boxen-bottle-hooks.rb#L31) to fail.
