### PR TITLE
Fix package version check

### DIFF
--- a/files/boxen-bottle-hooks.rb
+++ b/files/boxen-bottle-hooks.rb
@@ -10,7 +10,7 @@ require "base64"
 # Puppet so that manual installs and indirect dependencies are also supported.
 module BoxenBottles
   def self.file(formula)
-    "#{formula.name}-#{formula.version}.tar.bz2"
+    "#{formula.name}-#{formula.pkg_version}.tar.bz2"
   end
 
   def self.url(formula)

--- a/files/brew-boxen-latest.rb
+++ b/files/brew-boxen-latest.rb
@@ -6,4 +6,4 @@ require File.expand_path("#{File.dirname(__FILE__)}/boxen-bottle-hooks")
 #
 #   $ brew boxen-latest <formula-name>
 raise FormulaUnspecifiedError if ARGV.named.empty?
-puts ARGV.formulae.first.version
+puts ARGV.formulae.first.pkg_version


### PR DESCRIPTION
Homebrew has encoded formula revision to installation prefix.

See https://github.com/Homebrew/homebrew/commit/fbfc6d.

A rebased version of @hanjianwei's work in #56.

Fixes #55.
Fixes #56.
Fixes https://github.com/boxen/our-boxen/issues/716.