### PR TITLE
init: create the boxen tapsdir root directory.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -86,7 +86,14 @@ class homebrew(
   }
 
   file {
-    [$cachedir, $tapsdir, $cmddir, $brewsdir, "${brewsdir}/cmd"]:
+    [
+      $cachedir,
+      $tapsdir,
+      $cmddir,
+      "${tapsdir}/boxen",
+      $brewsdir,
+      "${brewsdir}/cmd"
+    ]:
       ensure => 'directory' ;
 
     # shim for bottle hooks


### PR DESCRIPTION
Otherwise the boxen tap directory may fail to be created.