### PR TITLE
Fix downgrading packages.

### DIFF
--- a/files/brew-boxen-upgrade.rb
+++ b/files/brew-boxen-upgrade.rb
@@ -1,5 +1,0 @@
-require File.expand_path("#{File.dirname(__FILE__)}/boxen-bottle-hooks")
-require "cmd/upgrade"
-
-# A custom Homebrew command that loads our bottle hooks.
-Homebrew.upgrade

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -103,8 +103,6 @@ class homebrew(
       source  => 'puppet:///modules/homebrew/brew-boxen-latest.rb' ;
     "${brewsdir}/cmd/brew-boxen-install.rb":
       source  => 'puppet:///modules/homebrew/brew-boxen-install.rb' ;
-    "${brewsdir}/cmd/brew-boxen-upgrade.rb":
-      source  => 'puppet:///modules/homebrew/brew-boxen-upgrade.rb' ;
   }
 
   ->
@@ -114,6 +112,7 @@ class homebrew(
       "${boxen::config::envdir}/30_homebrew.sh",
       "${boxen::config::envdir}/cflags.sh",
       "${boxen::config::envdir}/ldflags.sh",
+      "${brewsdir}/cmd/brew-boxen-upgrade.rb",
     ]:
       ensure => absent,
   }

--- a/spec/classes/homebrew_spec.rb
+++ b/spec/classes/homebrew_spec.rb
@@ -23,7 +23,7 @@ describe "homebrew" do
     should contain_file("#{cmddir}/boxen-bottle-hooks.rb").
       with_source("puppet:///modules/homebrew/boxen-bottle-hooks.rb")
 
-    ["latest", "install", "upgrade"].each do |cmd|
+    ["latest", "install"].each do |cmd|
       should contain_file("#{cmddir}/brew-boxen-#{cmd}.rb").
         with_source("puppet:///modules/homebrew/brew-boxen-#{cmd}.rb")
     end


### PR DESCRIPTION
Boxen is quite insistent about what versions it wants to be installed. If the version installed does not exactly match the version it wants it's going to try to `upgrade` to it. Unfortunately Homebrew doesn'tallow `brew upgrade` to downgrade software so the two contradict.

Instead of relying on `brew upgrade` instead just `brew unlink` first which lets you install (and link) whatever version you want. It also let's us kill even more Boxen-specific code.