### PR TITLE
Use default Homebrew paths unless Boxen's exists.

### DIFF
--- a/lib/facter/homebrew_root.rb
+++ b/lib/facter/homebrew_root.rb
@@ -4,5 +4,11 @@ Facter.add(:homebrew_root) do
   # Explicit, low weight makes this easily overridable
   has_weight 1
 
-  setcode { "#{Facter.value(:boxen_home)}/homebrew" }
+  setcode do
+    if File.exist? "#{Facter.value(:boxen_home)}/homebrew/bin/brew"
+      "#{Facter.value(:boxen_home)}/homebrew"
+    else
+      "/usr/local"
+    end
+  end
 end

--- a/lib/puppet/provider/package/homebrew.rb
+++ b/lib/puppet/provider/package/homebrew.rb
@@ -18,7 +18,8 @@ Puppet::Type.type(:package).provide :homebrew, :parent => Puppet::Provider::Pack
   end
 
   def self.cache
-    if boxen_home = Facter.value(:boxen_home)
+    boxen_home = Facter.value(:boxen_home)
+    if boxen_home && File.exist?("#{boxen_home}/cache/homebrew")
       "#{boxen_home}/cache/homebrew"
     else
       ENV["HOMEBREW_CACHE"] || "/Library/Caches/Homebrew"


### PR DESCRIPTION
`/usr/local` Homebrew is working well and well supported for Boxen now.
We don't want to force all users to move to `/usr/local` but if they are doing a fresh install on a new system then let's default to using `/usr/local` rather than e.g. `/opt/boxen/homebrew`.