### PR TITLE
Fish Compatibility

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -119,9 +119,10 @@ class homebrew(
 
   ->
   boxen::env_script { 'homebrew-fish':
-    content   => template('homebrew/env.fish.erb'),
-    priority  => highest,
-    extension => 'fish',
+    content    => template('homebrew/env.fish.erb'),
+    priority   => highest,
+    scriptname => 'homebrew',
+    extension  => 'fish',
   }
   boxen::env_script { 'homebrew':
     content  => template('homebrew/env.sh.erb'),

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -119,6 +119,10 @@ class homebrew(
 
   ->
   boxen::env_script { 'homebrew':
+    content  => template('homebrew/env.fish.erb'),
+    priority => highest,
+  }
+  boxen::env_script { 'homebrew':
     content  => template('homebrew/env.sh.erb'),
     priority => highest,
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -118,7 +118,7 @@ class homebrew(
   }
 
   ->
-  boxen::env_script { 'homebrew':
+  boxen::env_script { 'homebrew-fish':
     content  => template('homebrew/env.fish.erb'),
     priority => highest,
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -119,8 +119,9 @@ class homebrew(
 
   ->
   boxen::env_script { 'homebrew-fish':
-    content  => template('homebrew/env.fish.erb'),
-    priority => highest,
+    content   => template('homebrew/env.fish.erb'),
+    priority  => highest,
+    extension => 'fish',
   }
   boxen::env_script { 'homebrew':
     content  => template('homebrew/env.sh.erb'),

--- a/templates/env.fish.erb
+++ b/templates/env.fish.erb
@@ -13,8 +13,8 @@ set -gx LDFLAGS "-L$HOMEBREW_ROOT/lib"
 
 # Add homebrew'd stuff to the path.
 
-set -gx PATH $HOMEBREW_ROOT/bin:$HOMEBREW_ROOT/sbin:$PATH
+set -gx PATH $HOMEBREW_ROOT/bin $HOMEBREW_ROOT/sbin $PATH
 
 # Add homebrew'd stuff to the manpath.
 
-set -gx MANPATH $HOMEBREW_ROOT/share/man:$MANPATH
+set -gx MANPATH $HOMEBREW_ROOT/share/man $MANPATH


### PR DESCRIPTION
Adds a Fish version of the env script. 

Relies on boxen/puppet-boxen#138 (for the `extension` argument to `env_script`).
