### PR TITLE
Rollback to last known working version of `puppet-homebrew`

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -16,5 +16,5 @@ class homebrew::config {
 
   $brewsdir   = "${tapsdir}/boxen/homebrew-brews"
 
-  $min_revision = 'e90b6e9ded2fd2c73a4e0d93f5dbc5b075a61b7c'
+  $min_revision = 'fbc5fc3e92587b47ddd8d8a97eb8e3a138d72957'
 }


### PR DESCRIPTION
After running `brew update` I was confronted with the following error:

```
Error:
/Stage[main]/Homebrew::Repo/Homebrew_repo[/opt/boxen/homebrew]/min_revision:
change from fbc5fc3e92587b47ddd8d8a97eb8e3a138d72957 to
e90b6e9ded2fd2c73a4e0d93f5dbc5b075a61b7c failed: Execution of 'brew update'
returned 1: Error: Cowardly refusing to 'sudo brew update'
```

After a bit of poking around, this turned out to be caused by the upstream
homebrew repositories splitting into two smaller repositories.

To fix this in the short term I'm dropping back to the older minimum required
version and in the long run I'll look to work out what we need to do in order to
get back on the latest and use the two repositories.

Fixes #91.

cc @salimane @mikemcquaid