### PR TITLE
Run brew as the current boxen user, fixes #91

### DIFF
--- a/lib/puppet/provider/homebrew_repo/homebrew.rb
+++ b/lib/puppet/provider/homebrew_repo/homebrew.rb
@@ -84,7 +84,7 @@ Puppet::Type.type(:homebrew_repo).provide :homebrew do
   end
   
   def brew_command_opts
-    default_command_opts.merge({
+    build_command_opts.merge({
       :custom_environment => {
         "HOME"            => "/#{homedir_prefix}/#{@resource[:user]}",
         "PATH"            => "#{self.class.home}/bin:/usr/bin:/usr/sbin:/bin:/sbin",

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -12,7 +12,7 @@ class homebrew(
   $tapsdir      = $homebrew::config::tapsdir,
   $brewsdir     = $homebrew::config::brewsdir,
   $min_revision = $homebrew::config::min_revision,
-  $repo         = 'Homebrew/homebrew',
+  $repo         = 'Homebrew/brew',
   $set_cflags   = true,
   $set_ldflags  = true,
 ) inherits homebrew::config {


### PR DESCRIPTION
It seems brew has always run as root in boxen. With this PR, it will run by default as the boxen user.

This PR also includes:
- Changing the default homebrew repo to homebrew/brew
This PR also 

Signed-off-by: Salimane Adjao Moustapha <me@salimane.com>