### PR TITLE
Use ruby 2.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,4 @@
 script: "./script/cibuild"
 gemfile: "this/does/not/exist"
 rvm:
-  - "1.8.7"
+  - "2.0.0"


### PR DESCRIPTION
Hi, update ruby version for travis ci.
Because macOS default ruby version is 2.0.