### PR TITLE
Force brew to stay on v1.2.6

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -16,5 +16,5 @@ class homebrew::config {
 
   $brewsdir   = "${tapsdir}/boxen/homebrew-brews"
 
-  $min_revision = 'd5b6ecfc5078041ddf5f61b259c57f81d5c50fcc'
+  $min_revision = '867590b648674a1cda1cad68ba50d9f861b12bfe' # v1.2.6
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -57,7 +57,9 @@ class homebrew(
                 git config remote.origin.url https://github.com/${repo} &&
                 git config remote.origin.fetch master:refs/remotes/origin/master &&
                 git fetch origin master:refs/remotes/origin/master -n &&
-                git reset --hard origin/master",
+                git reset --hard origin/master &&
+                git fetch --tags &&
+                git checkout 1.2.6",
     cwd     => $installdir,
     user    => $::boxen_user,
     creates => "${installdir}/.git",

--- a/templates/env.sh.erb
+++ b/templates/env.sh.erb
@@ -1,5 +1,6 @@
 export HOMEBREW_ROOT=<%= @installdir %>
 export HOMEBREW_CACHE=<%= @cachedir %>
+export HOMEBREW_NO_AUTO_UPDATE=1
 
 export BOXEN_HOMEBREW_BOTTLE_URL=<%= scope.lookupvar("::homebrew_bottle_url") %>
 


### PR DESCRIPTION
There are issues with the latest version of homebrew:

* Nginx, and other services, can now only have its config in /etc
* ICU4C was upgraded and is no longer compatible with El Capitan

https://github.com/boxen/puppet-nginx/issues/50
https://github.com/boxen/puppet-nginx/pull/51